### PR TITLE
Fix pytest vulnerability

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,7 @@ mypy==0.960
 mypy-extensions==0.4.3
 numpy==1.23.1
 pip-tools==6.6.2
-pytest==7.1.2
+pytest==7.2.0
 pytest-cov==3.0.0
 pytest-mock==3.7.0
 scikit-learn==1.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,8 @@ coverage[toml]==6.5.0
     # via pytest-cov
 distlib==0.3.6
     # via virtualenv
+exceptiongroup==1.0.4
+    # via pytest
 filelock==3.8.0
     # via
     #   tox
@@ -54,22 +56,20 @@ pluggy==1.0.0
     #   pytest
     #   tox
 py==1.11.0
-    # via
-    #   pytest
-    #   tox
+    # via tox
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.2.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
     #   pytest-mock
 pytest-cov==3.0.0
-# via -r requirements-dev.in
+    # via -r requirements-dev.in
 pytest-mock==3.7.0
     # via -r requirements-dev.in
 scikit-learn==1.1.1


### PR DESCRIPTION
This PR adds a fix to the `pytest` vulnerability flagged by the Dependabot. (https://github.com/kritchie/LIBiFBTSVM/security/dependabot/9)
Updates `pytest` to `7.2.0` 